### PR TITLE
Fix empty slice not allocated

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -840,8 +840,8 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 
 		}
 
-		// If the input value is empty, then don't allocate since non-nil != nil
-		if dataVal.Len() == 0 {
+		// If the input value is nil, then don't allocate since empty != nil
+		if dataVal.IsNil() {
 			return nil
 		}
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1546,6 +1546,17 @@ func TestDecodeTable(t *testing.T) {
 			false,
 		},
 		{
+			"struct with empty slice",
+			&map[string]interface{}{
+				"Vbar": []string{},
+			},
+			&Slice{},
+			&Slice{
+				Vbar: []string{},
+			},
+			false,
+		},
+		{
 			"struct with slice of struct property",
 			&SliceOfStruct{
 				Value: []Basic{


### PR DESCRIPTION
We are forking mapstructure and applying zhsj's fix for the empty slice not allocated problem.  This problem shows up in one of our services when we are testing if an array from a response is NIL.  Without this fix, an empty slice is converted to NIL and erroneously passes the test.  We have to be able to tell the difference between a passed in empty slice and nothing passed in for the field (NIL).  Before this fix, that is not possible.